### PR TITLE
🐛 중복 해싱 버그 수정

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -14,9 +14,11 @@ const LoginPage = () => {
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError("");
 
     const success = await login(user_id, password);
     if (success) {
+      alert("환영합니다!");
       navigate("/");
     } else {
       setError("아이디 또는 비밀번호를 확인하세요.");
@@ -27,14 +29,13 @@ const LoginPage = () => {
     <Container maxWidth="xs">
       <Box sx={{ mt: 10, textAlign: "center" }}>
         <Typography variant="h5">로그인</Typography>
-        {error && <Typography color="error">{error}</Typography>}
+        {error && <Typography color="error" sx={{ mt: 2 }}>{error}</Typography>}
 
         <form onSubmit={handleLogin}>
           <TextField
             label="아이디"
             fullWidth
             margin="normal"
-            className="auth-textfield"
             value={user_id}
             onChange={(e) => setUserId(e.target.value)}
             autoComplete="username"
@@ -45,21 +46,22 @@ const LoginPage = () => {
             type={showPassword ? "text" : "password"}
             fullWidth
             margin="normal"
-            className="auth-textfield"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="current-password"
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton onClick={() => setShowPassword(!showPassword)} edge="end">
-                    {showPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              )
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowPassword(!showPassword)} edge="end">
+                      {showPassword ? <Visibility /> : <VisibilityOff />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
             }}
           />
-          
+
           <Button 
             type="submit" 
             variant="contained" 

--- a/client/src/pages/SignupPage.tsx
+++ b/client/src/pages/SignupPage.tsx
@@ -45,21 +45,22 @@ const SignupPage = () => {
   const handleSignup = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
-
+  
     const validationError = validateSignupForm(form);
     if (validationError) {
       setError(validationError);
       return;
     }
-
+  
     try {
       setLoading(true);
+  
       await axios.post(`${import.meta.env.VITE_API_BASE_URL}/auth/signup`, {
         user_id: form.userId,
         username: form.username,
         password: form.password,
       });
-
+  
       alert("회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.");
       navigate("/login");
     } catch (err: any) {
@@ -76,65 +77,16 @@ const SignupPage = () => {
         {error && <Typography color="error" sx={{ mt: 2 }}>{error}</Typography>}
 
         <form onSubmit={handleSignup}>
-          <TextField
-            name="userId"
-            label="아이디"
-            fullWidth margin="normal"
-            value={form.userId}
-            onChange={handleChange}
-            helperText="아이디는 최소 8자 이상, 영문과 숫자를 포함해야 합니다."
-          />
-          <TextField
-            name="username"
-            label="닉네임"
-            fullWidth margin="normal"
-            value={form.username}
-            onChange={handleChange}
-            autoComplete="username"
-            helperText="닉네임은 최소 2자 이상이며, 영문, 한글, 숫자만 가능합니다."
-          />
+          <TextField name="userId" label="아이디" fullWidth margin="normal" value={form.userId} onChange={handleChange} helperText="아이디는 최소 8자 이상, 영문과 숫자를 포함해야 합니다." />
+          <TextField name="username" label="닉네임" fullWidth margin="normal" value={form.username} onChange={handleChange} autoComplete="username" helperText="닉네임은 최소 2자 이상이며, 영문, 한글, 숫자만 가능합니다." />
 
-          <TextField
-            name="password"
-            label="비밀번호"
-            type={showPassword ? "text" : "password"}
-            fullWidth margin="normal"
-            value={form.password}
-            onChange={handleChange}
-            autoComplete="new-password"
+          <TextField name="password" label="비밀번호" type={showPassword ? "text" : "password"} fullWidth margin="normal" value={form.password} onChange={handleChange} autoComplete="new-password"
             helperText="비밀번호는 최소 8자 이상, 영문과 숫자를 포함해야 합니다."
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton onClick={() => setShowPassword(!showPassword)} edge="end">
-                      {showPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              },
-            }}
+            slotProps={{ input: { endAdornment: (<InputAdornment position="end"><IconButton onClick={() => setShowPassword(!showPassword)} edge="end">{showPassword ? <Visibility /> : <VisibilityOff />}</IconButton></InputAdornment>) } }}
           />
 
-          <TextField
-            name="confirmPassword"
-            label="비밀번호 확인"
-            type={showConfirmPassword ? "text" : "password"}
-            fullWidth margin="normal"
-            value={form.confirmPassword}
-            onChange={handleChange}
-            autoComplete="new-password"
-            slotProps={{
-              input: {
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton onClick={() => setShowConfirmPassword(!showConfirmPassword)} edge="end">
-                      {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              },
-            }}
+          <TextField name="confirmPassword" label="비밀번호 확인" type={showConfirmPassword ? "text" : "password"} fullWidth margin="normal" value={form.confirmPassword} onChange={handleChange} autoComplete="new-password"
+            slotProps={{ input: { endAdornment: (<InputAdornment position="end"><IconButton onClick={() => setShowConfirmPassword(!showConfirmPassword)} edge="end">{showConfirmPassword ? <Visibility /> : <VisibilityOff />}</IconButton></InputAdornment>) } }}
           />
 
           <Button type="submit" variant="contained" color="primary" fullWidth disabled={loading} sx={{ mt: 2 }}>
@@ -142,10 +94,7 @@ const SignupPage = () => {
           </Button>
         </form>
 
-        <Typography onClick={() => navigate("/login")} sx={{
-          mt: 2, cursor: "pointer", textDecoration: "none",
-          color: "primary.main", "&:hover": { textDecoration: "underline" }
-        }}>
+        <Typography onClick={() => navigate("/login")} sx={{ mt: 2, cursor: "pointer", textDecoration: "none", color: "primary.main", "&:hover": { textDecoration: "underline" } }}>
           로그인 페이지로 이동
         </Typography>
       </Box>

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -6,37 +6,27 @@ const { jwtSecret, jwtExpiresIn } = require('../config/jwt');
 const signup = async (req, res) => {
   try {
     const { user_id, username, password } = req.body;
-    
+
     if (!user_id || !username || !password) {
       return res.status(400).json({ message: "모든 필드를 입력해주세요." });
     }
 
     const existingUser = await User.findOne({ $or: [{ user_id }, { username }] });
     if (existingUser) {
-      if (existingUser.user_id === user_id) {
-        return res.status(400).json({ message: "이미 사용 중인 아이디입니다." });
-      }
-      if (existingUser.username === username) {
-        return res.status(400).json({ message: "이미 사용 중인 닉네임입니다." });
-      }
+      return res.status(400).json({
+        message: existingUser.user_id === user_id
+          ? "이미 사용 중인 아이디입니다."
+          : "이미 사용 중인 닉네임입니다."
+      });
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);
-    
     const newUser = new User({ user_id, username, password: hashedPassword });
+
     await newUser.save();
 
     res.status(201).json({ message: "회원가입 성공" });
   } catch (error) {
-    console.error(error);
-
-    if (error.code === 11000) {
-      const duplicatedField = Object.keys(error.keyPattern)[0];
-      return res.status(400).json({
-        message: `이미 사용 중인 ${duplicatedField === 'user_id' ? '아이디' : '닉네임'}입니다.`,
-      });
-    }
-
     res.status(500).json({ message: "서버 오류 발생" });
   }
 };
@@ -44,6 +34,7 @@ const signup = async (req, res) => {
 const login = async (req, res) => {
   try {
     const { user_id, password } = req.body;
+
     if (!user_id || !password) {
       return res.status(400).json({ message: "아이디와 비밀번호를 입력해주세요." });
     }
@@ -60,9 +51,13 @@ const login = async (req, res) => {
 
     const token = jwt.sign({ id: user._id, user_id: user.user_id }, jwtSecret, { expiresIn: jwtExpiresIn });
 
-    res.status(200).json({ message: "로그인 성공", token, user: { id: user._id, user_id: user.user_id, username: user.username } });
+    res.status(200).json({
+      message: "로그인 성공",
+      token,
+      user: { id: user._id, user_id: user.user_id, username: user.username },
+    });
   } catch (error) {
-    res.status(500).json({ message: "서버 오류", error });
+    res.status(500).json({ message: "서버 오류 발생" });
   }
 };
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const bcrypt = require('bcryptjs');
 
 const UserSchema = new mongoose.Schema({
     user_id: { type: String, required: true, unique: true },
@@ -7,13 +6,6 @@ const UserSchema = new mongoose.Schema({
     password: { type: String, required: true },
     points: { type: Number, default: 0 },
     createdAt: { type: Date, default: Date.now }
-});
-
-UserSchema.pre('save', async function (next) {
-    if (!this.isModified('password')) return next();
-    const salt = await bcrypt.genSalt(10);
-    this.password = await bcrypt.hash(this.password, salt);
-    next();
 });
 
 module.exports = mongoose.model('User', UserSchema);


### PR DESCRIPTION
# 🔥 Pull Request Template

## ✅ 반영 브랜치
`feature/auth` → `develop`

## ✅ PR 개요
<!-- 이번 PR에서 변경된 내용을 간략히 설명해주세요. -->
- 회원가입 시 중복 해싱 버그 수정
- Mongoose pre("save") 훅 제거하여 비밀번호가 두 번 해싱되는 문제 해결
- 회원가입 & 로그인 로직 리팩토링하여 유지보수성 향상

## 🛠 변경 사항
<!-- 어떤 기능이 추가되거나 변경되었는지 상세히 설명해주세요. -->
- Mongoose 모델에서 pre("save") 훅 제거
   - 기존 pre("save")에서 비밀번호를 다시 해싱하는 문제가 발생 → 제거 후 회원가입 API에서 해싱을 수행하도록 변경
- 회원가입 API (signup) 수정
   - bcrypt.hash()를 회원가입 API 내에서 실행하여 중복 해싱 방지
   - 기존 계정 존재 여부 확인 로직 최적화
- 로그인 API (login) 수정
   - bcrypt.compare()를 통해 로그인 시 비밀번호 검증 정상 작동 확인
- 회원가입 프론트엔드 코드 리팩토링
   - slotProps 대신 InputProps 적용하여 최신 MUI 방식 적용

## 🚀 테스트 체크리스트
- [x] 주요 기능이 정상적으로 동작하는지 확인
- [x] 예상치 못한 오류가 발생하지 않는지 확인
- [x] UI/UX 관련 변경 사항을 점검
- [x] 코드 리뷰 및 리팩토링 완료

## 🔎 기타 참고 사항
<!-- 추가적으로 공유할 사항이 있다면 입력해주세요. -->
- 
